### PR TITLE
added a check whether a value is an instance of a Date

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 function isObject(o) {
-  if ('object' === typeof o && !(o instanceof Array)) {
+  if ('object' === typeof o && !(o instanceof Array) && !(o instanceof Date)) {
     return true;
   }
 

--- a/package.json
+++ b/package.json
@@ -5,5 +5,6 @@
     "mocha": "^2.2.5"
   },
   "scripts": {
-    "test": "mocha" }
+    "test": "mocha"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -3,5 +3,7 @@
   "version": "0.2.0",
   "devDependencies": {
     "mocha": "^2.2.5"
-  }
+  },
+  "scripts": {
+    "test": "mocha" }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -256,4 +256,63 @@ describe('trample', function() {
 
     assert.equal(res['foo_bar'], 'baz');
   });
+  it('should flatten object, keep the date value intact', function() {
+    var date_val = new Date();
+    var obj = {
+      'foobar123': {
+        'cat': 123,
+      },
+      'date': date_val
+    };
+
+    var res = trample(obj);
+    assert.equal(res['foobar123.cat'], 123);
+    assert.equal(res['date'], date_val);
+  });
+
+  it('should flatten nested object, keep the date value intact', function() {
+    var date_val = new Date();
+    var obj = {
+      'foobar123': {
+        'cat': 123,
+        'date': date_val
+      }
+    };
+
+    var res = trample(obj, );
+    assert.equal(res['foobar123.cat'], 123);
+    assert.equal(res['foobar123.date'], date_val);
+  });
+
+  it('should flatten array, keep the date value intact', function() {
+    var date_val = new Date();
+    var obj = {
+      'foobar123': {
+        'cat': 123,
+        'arr': [1,'a', date_val]
+      }
+    };
+
+    var res = trample(obj, { flattenArray: true });
+    assert.equal(res['foobar123.cat'], 123);
+    assert.equal(res['foobar123.arr.0'], 1);
+    assert.equal(res['foobar123.arr.1'], 'a');
+    assert.equal(res['foobar123.arr.2'], date_val);
+  });
+
+  it('should process array, keep the date value intact', function() {
+    var date_val = new Date();
+    var obj = {
+      'foobar123': {
+        'cat': 123,
+        'arr': [1,'a', date_val]
+      }
+    };
+
+    var res = trample(obj, { flattenArray: false });
+    assert.equal(res['foobar123.cat'], 123);
+    assert.equal(res['foobar123.arr'][0], 1);
+    assert.equal(res['foobar123.arr'][1], 'a');
+    assert.equal(res['foobar123.arr'][2], date_val);
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -301,12 +301,12 @@ describe('trample', function() {
     assert.equal(res['foobar123.arr.2'], dateVal);
   });
 
-  it('should process array, keep the date value intact', function() {
-    var date_val = new Date();
+  it('should keep date objects intact when processing, but not flattening, arrays', function() {
+    var dateVal = new Date();
     var obj = {
-      'foobar123': {
-        'cat': 123,
-        'arr': [1,'a', date_val]
+      foobar123: {
+        cat: 123,
+        arr: [1,'a', dateVal]
       }
     };
 
@@ -314,6 +314,6 @@ describe('trample', function() {
     assert.equal(res['foobar123.cat'], 123);
     assert.equal(res['foobar123.arr'][0], 1);
     assert.equal(res['foobar123.arr'][1], 'a');
-    assert.equal(res['foobar123.arr'][2], date_val);
+    assert.equal(res['foobar123.arr'][2], dateVal);
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -256,18 +256,19 @@ describe('trample', function() {
 
     assert.equal(res['foo_bar'], 'baz');
   });
-  it('should flatten object, keep the date value intact', function() {
-    var date_val = new Date();
+  
+  it('should keep date objects intact when flattening objects', function() {
+    var dateVal = new Date();
     var obj = {
-      'foobar123': {
-        'cat': 123,
+      foobar123: {
+        cat: 123,
       },
-      'date': date_val
+      date: dateVal
     };
 
     var res = trample(obj);
     assert.equal(res['foobar123.cat'], 123);
-    assert.equal(res['date'], date_val);
+    assert.equal(res['date'], dateVal);
   });
 
   it('should flatten nested object, keep the date value intact', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -285,12 +285,12 @@ describe('trample', function() {
     assert.equal(res['foobar123.date'], date_val);
   });
 
-  it('should flatten array, keep the date value intact', function() {
-    var date_val = new Date();
+  it('should keep date objects intact when flattening arrays', function() {
+    var dateVal = new Date();
     var obj = {
-      'foobar123': {
-        'cat': 123,
-        'arr': [1,'a', date_val]
+      foobar123: {
+        cat: 123,
+        arr: [1,'a', dateVal]
       }
     };
 
@@ -298,7 +298,7 @@ describe('trample', function() {
     assert.equal(res['foobar123.cat'], 123);
     assert.equal(res['foobar123.arr.0'], 1);
     assert.equal(res['foobar123.arr.1'], 'a');
-    assert.equal(res['foobar123.arr.2'], date_val);
+    assert.equal(res['foobar123.arr.2'], dateVal);
   });
 
   it('should process array, keep the date value intact', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -271,16 +271,16 @@ describe('trample', function() {
     assert.equal(res['date'], dateVal);
   });
 
-  it('should flatten nested object, keep the date value intact', function() {
-    var date_val = new Date();
+  it('should keep date objects intact when flattening nested objects', function() {
+    var dateVal = new Date();
     var obj = {
-      'foobar123': {
-        'cat': 123,
-        'date': date_val
+      foobar123: {
+        cat: 123,
+        date: dateVal
       }
     };
 
-    var res = trample(obj, );
+    var res = trample(obj);
     assert.equal(res['foobar123.cat'], 123);
     assert.equal(res['foobar123.date'], date_val);
   });


### PR DESCRIPTION
**Changes / updates:**

- This update aims to fix the issue with trample dropping Date values: [Jira ticket](https://segment.atlassian.net/browse/STRATCONN-285)
- The change is made to the `isObject` function, which now returns `false` when a value is an instance of a Date, i.e. Date objects are treated as "leafs" of the tree structure. Previously Date values were treated as objects (JSON), i.e. nested structures which trample was attempting to flatten. That in turn led to the values being dropped.
- Date objects are returned 'as is', i.e. we don't convert them into a string or ISO string. The logic is similar to processing the booleans / numbers: we keep the original type of the value.

See the 2 before / after screenshots.

Before the change - note missing Date values in the output:

<img src="https://user-images.githubusercontent.com/27460815/144534093-acf89a1b-2c76-49a4-acf8-8651f26a9293.png" width="500">


After the change - Date objects are present in the output:

<img src="https://user-images.githubusercontent.com/27460815/144534323-423f90fb-3bcf-418f-8e1a-a5ad7e23639b.png" width="500">


